### PR TITLE
Fix emdash in release notes

### DIFF
--- a/cabal-website.cabal
+++ b/cabal-website.cabal
@@ -8,5 +8,6 @@ executable site
   build-depends:    base >=4.17 && <5
                   , hakyll
                   , filepath
+                  , pandoc
   ghc-options:      -threaded
   default-language: Haskell2010

--- a/site.hs
+++ b/site.hs
@@ -6,10 +6,20 @@ import Data.Function (on)
 import Data.List (isPrefixOf, sortBy, stripPrefix)
 import Data.Ord (Down (..))
 import Data.Version (Version (..), parseVersion)
-import Hakyll
+import Hakyll hiding (pandocCompiler)
 import Hakyll.Core.Item (Item (..))
 import System.FilePath (takeBaseName, (</>))
+import Text.Pandoc.Options
 import Text.ParserCombinators.ReadP (ReadP, readP_to_S)
+
+pandocCompiler :: Compiler (Item String)
+pandocCompiler =
+    pandocCompilerWith
+        defaultHakyllReaderOptions
+            { readerExtensions =
+                disableExtension Ext_smart $ readerExtensions defaultHakyllReaderOptions
+            }
+        defaultHakyllWriterOptions
 
 main :: IO ()
 main = hakyll $ do


### PR DESCRIPTION
Fixes #3 by not reading `--` as en-dash, by not enabling the [smart extension](https://pandoc.org/chunkedhtml-demo/7.1-typography.html).